### PR TITLE
Adds option to stream from replay API in new development-replay environment

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -67,6 +67,14 @@
                 }
               ]
             },
+            "development-replay": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.dev.replay.ts"
+                }
+              ],
+            },
             "ci": {
               "progress": false
             }
@@ -80,6 +88,9 @@
           "configurations": {
             "production": {
               "browserTarget": "app:build:production"
+            },
+            "development-replay": {
+              "browserTarget": "app:build:development-replay"
             },
             "ci": {
               "progress": false

--- a/src/environments/environment.dev.replay.ts
+++ b/src/environments/environment.dev.replay.ts
@@ -1,0 +1,23 @@
+export const environment = {
+  production: false,
+  useReplay: true,
+  replayUrl: 'https://api.sibr.dev/replay/v1/replay',
+  replayFrom: '2020-08-30T01:00:08.17Z',
+  // the replay API uses a default interval of 3000ms between events
+  // which currently makes the stream restart too frequently
+  replayInterval: 1500,
+  // how many events should the replay stream?
+  replayCount: 100
+};
+
+/*
+ * replayFrom timestamps reference, with Reblase links
+ * ---------------------------------------------------
+ * s4 d112
+ * 2020-08-30T01:00:08.17Z
+ * https://reblase.sibr.dev/game/628a2ddb-f608-411b-8d2e-2768cd36d58b
+ *
+ * s12 d116
+ * 2021-03-06T23:00:00.907735Z
+ * https://reblase.sibr.dev/game/0f19d78d-c27d-4146-863d-b55e6dae1679
+ */

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,8 @@
 export const environment = {
-  production: true
+  production: true,
+  useReplay: false,
+  replayUrl: '',
+  replayFrom: '',
+  replayInterval: '',
+  replayCount: ''
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,12 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  useReplay: false,
+  replayUrl: '',
+  replayFrom: '',
+  replayInterval: '',
+  replayCount: ''
 };
 
 /*


### PR DESCRIPTION
### Changes

1. Adds a new build environment called `development-replay`, which connects to the replay API for the data stream

2. Adds replay API settings & options in `src/environments/environments.dev.replay.ts`

  - ~~the URL for the replay API is defined here because as of my writing this, the replay API has a couple bugs that need fixing. [See this PR in the replay repo](https://github.com/BeeFox-sys/Review/pull/1). In the meantime, the changes in this repo can be tested by downloading [my fixed version of the replay API](https://github.com/hora/Review/tree/bug-fix/reverse-stream-order), running it locally, and setting that as the `replayURL`.~~ Update: the Replay API is fixed.

3. Updates `src/lib/spi/stream.ts` to check whether it should connect to the live stream, or the replay API stream.

  - Since the replay API closes a stream after a set amount of messages, I've set it up so that the stream just restarts when this limit is reached. This should be fine for testing/dev purposes, since you can change the timestamp from which to start replaying if you need to check more events after the limit.

### Todo
- [ ] Adding another environment broke some tests, gotta look into why, and to fix that
- [ ] Update README with instructions how to use the replay API in development
- [ ] Maybe also test on mobile?