### PR TITLE
Bug fix: show standings during Lateseason

### DIFF
--- a/src/lib/model/sim.ts
+++ b/src/lib/model/sim.ts
@@ -56,6 +56,7 @@ export class Sim extends Entry {
       case PHASES.EARLY_SIESTA:
       case PHASES.MIDSEASON:
       case PHASES.LATE_SIESTA:
+      case PHASES.LATESEASON:
       case PHASES.SEASON_END:
         return true;
       default:


### PR DESCRIPTION
With a few games left to the season, b-l was showing the `Matchups` tab instead of the `Standings` tab.

I didn't notice when this broke, but it's been Lateseason for a while so it should in theory have been broken since the end of the Latesiesta.

I haven't double-checked whether there's been any phase changes, but this fix seems like LATESEASON was just overlooked when the phases were refactored.