### PR TITLE
Fixes matchups page when teams are idling

### DIFF
--- a/src/app/matchups/matchups.page.html
+++ b/src/app/matchups/matchups.page.html
@@ -34,13 +34,14 @@
                     <span class="name">{{teams[matchup.homeTeam].fullName}}</span>
                   </div>
                 </ion-col>
-                <ion-col size="1" class="ion-text-start ion-align-items-center ion-no-margin ion-no-padding">
+                <ion-col size="1" class="ion-text-start ion-align-items-center
+                  ion-no-margin ion-no-padding" *ngIf="!matchup.idling">
                   <div class="wins" [style]="getStyle(matchup, 'home')">
                     {{matchup.homeWins}}
                   </div>
                 </ion-col>
               </ion-row>
-              <ion-row>
+              <ion-row *ngIf="!matchup.idling">
                 <ion-col size="2" class="ion-text-end ion-align-items-center ion-no-margin ion-no-padding">
                   <div class="seed" [style]="getStyle(matchup, 'away')">
                     {{matchup.awaySeed}}
@@ -55,6 +56,13 @@
                 <ion-col size="1" class="ion-text-start ion-align-items-center ion-no-margin ion-no-padding">
                   <div class="wins" [style]="getStyle(matchup, 'away')">
                     {{matchup.awayWins}}
+                  </div>
+                </ion-col>
+              </ion-row>
+              <ion-row *ngIf="matchup.idling">
+                <ion-col class="ion-text-center">
+                  <div class="idling">
+                    <span>idling ...</span>
                   </div>
                 </ion-col>
               </ion-row>
@@ -78,13 +86,14 @@
                     <span class="name">{{teams[matchup.homeTeam].fullName}}</span>
                   </div>
                 </ion-col>
-                <ion-col size="1" class="ion-text-start ion-align-items-center ion-no-margin ion-no-padding">
+                <ion-col size="1" class="ion-text-start ion-align-items-center
+                  ion-no-margin ion-no-padding" *ngIf="!matchup.idling">
                   <div class="wins" [style]="getStyle(matchup, 'home')">
                     {{matchup.homeWins}}
                   </div>
                 </ion-col>
               </ion-row>
-              <ion-row>
+              <ion-row *ngIf="!matchup.idling">
                 <ion-col size="2" class="ion-text-end ion-align-items-center ion-no-margin ion-no-padding">
                   <div class="seed" [style]="getStyle(matchup, 'away')">
                     {{matchup.awaySeed}}
@@ -99,6 +108,13 @@
                 <ion-col size="1" class="ion-text-start ion-align-items-center ion-no-margin ion-no-padding">
                   <div class="wins" [style]="getStyle(matchup, 'away')">
                     {{matchup.awayWins}}
+                  </div>
+                </ion-col>
+              </ion-row>
+              <ion-row *ngIf="matchup.idling">
+                <ion-col class="ion-text-center">
+                  <div class="idling">
+                    <span>idling ...</span>
                   </div>
                 </ion-col>
               </ion-row>

--- a/src/app/matchups/matchups.page.html
+++ b/src/app/matchups/matchups.page.html
@@ -34,8 +34,7 @@
                     <span class="name">{{teams[matchup.homeTeam].fullName}}</span>
                   </div>
                 </ion-col>
-                <ion-col size="1" class="ion-text-start ion-align-items-center
-                  ion-no-margin ion-no-padding" *ngIf="!matchup.idling">
+                <ion-col size="1" class="ion-text-start ion-align-items-center ion-no-margin ion-no-padding" *ngIf="!matchup.idling">
                   <div class="wins" [style]="getStyle(matchup, 'home')">
                     {{matchup.homeWins}}
                   </div>
@@ -86,8 +85,7 @@
                     <span class="name">{{teams[matchup.homeTeam].fullName}}</span>
                   </div>
                 </ion-col>
-                <ion-col size="1" class="ion-text-start ion-align-items-center
-                  ion-no-margin ion-no-padding" *ngIf="!matchup.idling">
+                <ion-col size="1" class="ion-text-start ion-align-items-center ion-no-margin ion-no-padding" *ngIf="!matchup.idling">
                   <div class="wins" [style]="getStyle(matchup, 'home')">
                     {{matchup.homeWins}}
                   </div>

--- a/src/app/matchups/matchups.page.scss
+++ b/src/app/matchups/matchups.page.scss
@@ -20,4 +20,8 @@ ion-col {
   .wins {
     padding-left: 0.4em;
   }
+
+  .idling {
+    font-style: italic;
+  }
 }

--- a/src/lib/model/matchup.ts
+++ b/src/lib/model/matchup.ts
@@ -21,4 +21,12 @@ export class Matchup extends Entry {
   public get gamesNeeded() {
     return this.data?.gamesNeeded === undefined? -1 : parseInt(this.data.gamesNeeded, 10);
   }
+
+  public get idling() {
+    if (this.awayTeam === null) {
+      return true;
+    }
+
+    return false;
+  }
 }


### PR DESCRIPTION
The matchups page was broken during round 1 of the playoffs because some of the teams were idling.

I updated the design to show this status, borrowing from the blaseball.com design. In Chrome's device viewer (iPhone 6/7/8), it looks like this:

![Screen Shot 2021-04-10 at 16 15 04](https://user-images.githubusercontent.com/83366/114283473-ef9e8200-9a17-11eb-9c32-c134835b60d9.png)

If you'd like to test this code, you'll need to apply the #254 diff and run in replay environment. The timestamp for the start of day 100 is `2021-04-09T21:21:41.611894Z`.