### PR TITLE
Updates audio description setting name

### DIFF
--- a/src/lib/settings.service.ts
+++ b/src/lib/settings.service.ts
@@ -9,7 +9,7 @@ const { Device, Storage } = Plugins;
 export type SEGMENT = 'all'|'active'|'favorites';
 export const COMM_LEVEL = {
   1: "The Gods's Original",
-  2: "The Gods's Original+",
+  2: "A Dash of Hubris (Gods's+)",
 } as const;
 
 export interface Settings {


### PR DESCRIPTION
A new threason is starting in a few days, figured I'd update the audio description name with something decent so the app can be updated with the new feature :)

We and always change it later if we have a better idea.